### PR TITLE
fix(learner-view): add missing tip dontated

### DIFF
--- a/src/react-router-pages/LearnerView.tsx
+++ b/src/react-router-pages/LearnerView.tsx
@@ -1084,6 +1084,7 @@ const LearnerView: React.FC = () => {
                     title: "Thank you!",
                     description: `You've successfully tipped $${tipAmount || trail?.suggestedInvestment || 25} to ${getCreatorName(trail?.creator)}!`,
                   });
+                  analyticsService.trackTipDonated(trail?.id || '', tipAmount);
                   setTipCompleted(true);
                   setShowTipModal(false);
                   showTipModalRef.current = false;


### PR DESCRIPTION
- api call was missing from the success callback on the stripe payment component handling the tip


FYI there is a component called TipPaymentModal which isn't curently being used which may have lead to confusion


@evanbnormal 